### PR TITLE
Debug: parseTime()

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,18 +43,16 @@ function gentable(){
 }
 
 function parseTime(timeCode){
-    re = /[MTWRFSU][1-9yznabcd]+/g;
-    timelist = timeCode.match(re);
+    timeCode += ','
+    re = /\-[A-Za-z0-9\[\]]+,/g
+    timelist = timeCode.replaceAll(re, ',').slice(0, -1).split(',')
     res = [];
-    if(timelist==null){
-        return res;
-    }
     timelist.forEach(T => {
         for(i=1;i<T.length;i++){
             res.push(T[0]+T[i]);
         }
     });
-    return res;
+    return res
 }
 
 function getCourseData(CourseID){


### PR DESCRIPTION
In previous version, parseTime('R56-CS105') returns ['R5', 'R6', 'S1'].
Regular expression `re = /\-[A-Za-z0-9\[\]]+,/g` does not always work.